### PR TITLE
temp: proxy pass traffic to app-not-available page

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,20 +1,24 @@
 server {
 
-  listen 80;
+    listen 80;
 
-  location / {
-    root /usr/share/nginx/html;
-    index index.html index.htm;
+    # APP NOT AVAILABLE
+    location / {
+        proxy_pass https://app-not-available-ai4w47mtcq-ew.a.run.app/;
+    }
 
-    # to redirect all the requests to index.html, 
-    # useful when you are using react-router
+    # APP
+    # location / {
+    #     root /usr/share/nginx/html;
+    #     index index.html index.htm;
 
-    try_files $uri /index.html;
-  }
+    #     # to redirect all the requests to index.html,
+    #     # useful when you are using react-router
+    #     try_files $uri /index.html;
+    # }
+    error_page 500 502 503 504 /50x.html;
 
-  error_page 500 502 503 504 /50x.html;
-
-  location = /50x.html {
-    root /usr/share/nginx/html;
-  }
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
 }


### PR DESCRIPTION
Sets up Nginx in such a way that all the traffic is proxy passed to the website showing a message that the app is down.