### PR TITLE
refactor: move button styles to base

### DIFF
--- a/src/components/ClosePosition/ClosePosition.tsx
+++ b/src/components/ClosePosition/ClosePosition.tsx
@@ -75,7 +75,7 @@ const Template = ({
           onChange={handleChange}
         />
         <button
-          className={`${buttonStyles.button} ${buttonStyles.secondary}`}
+          className={buttonStyles.secondary}
           onClick={() => handleClick(max)}
         >
           Max
@@ -149,9 +149,7 @@ const WithOption = ({ option }: Props) => {
               <Typography>Cannot close size 0</Typography>
             </Box>
           </Box>
-          <button className={buttonStyles.button} disabled>
-            Close selected
-          </button>
+          <button disabled>Close selected</button>
         </Box>
       </Template>
     );
@@ -181,9 +179,7 @@ const WithOption = ({ option }: Props) => {
               <Typography>Loading...</Typography>
             </Box>
           </Box>
-          <button className={buttonStyles.button} disabled>
-            Loading...
-          </button>
+          <button disabled>Loading...</button>
         </Box>
       </Template>
     );
@@ -270,7 +266,7 @@ const WithOption = ({ option }: Props) => {
           </Box>
         </Box>
         <button
-          className={`${buttonStyles.button} ${buttonStyles.green}`}
+          className={buttonStyles.green}
           onClick={() => close(premiaMath64)}
         >
           Close selected

--- a/src/components/ConnectWallet/AccountInfo.tsx
+++ b/src/components/ConnectWallet/AccountInfo.tsx
@@ -2,7 +2,7 @@ import { WalletIcon } from "../assets";
 import { useWallet } from "../../hooks/useWallet";
 import { openAccountDialog } from "../../redux/actions";
 import { addressElision } from "../../utils/utils";
-import styles from "./connect.module.css";
+import styles from "../../style/button.module.css";
 
 export const AccountInfo = () => {
   const wallet = useWallet();
@@ -24,7 +24,7 @@ export const AccountInfo = () => {
   const { address } = account;
 
   return (
-    <button onClick={handleClick} className={styles.button}>
+    <button className={styles.secondary} onClick={handleClick}>
       <>
         <WalletIcon sx={iconStyle} wallet={wallet} />
         {addressElision(address)}

--- a/src/components/ConnectWallet/Button.tsx
+++ b/src/components/ConnectWallet/Button.tsx
@@ -3,7 +3,7 @@ import { connect } from "starknetkit";
 import { useAccount } from "../../hooks/useAccount";
 import { connect as accountConnect } from "../../network/account";
 import { AccountInfo } from "./AccountInfo";
-import styles from "./connect.module.css";
+import styles from "../../style/button.module.css";
 import { isMainnet } from "../../constants/amm";
 import { SupportedWalletIds } from "../../types/wallet";
 import { userLpBalance } from "../Transfer/transfer";
@@ -121,7 +121,7 @@ export const WalletButton = () => {
   }
 
   return (
-    <button className={styles.button} onClick={handleConnect}>
+    <button className={styles.secondary} onClick={handleConnect}>
       Connect
     </button>
   );

--- a/src/components/ConnectWallet/connect.module.css
+++ b/src/components/ConnectWallet/connect.module.css
@@ -1,28 +1,6 @@
 .button {
-  align-items: center;
-  background-color: transparent;
   border: 2px solid #ffb300;
-  border-radius: 5px;
-  box-sizing: border-box;
   color: #ffb300;
-  cursor: pointer;
-  display: inline-flex;
-  fill: #000;
-  font-family: Neue Haas Grotesk, sans-serif;
-  font-size: 18px;
-  font-weight: 500;
-  height: 50px;
-  justify-content: center;
-  line-height: 24px;
-  min-width: 140px;
-  outline: 0;
-  padding: 0 17px;
-  text-align: center;
-  text-decoration: none;
-  transition: all .3s;
-  user-select: none;
-  -webkit-user-select: none;
-  touch-action: manipulation;
 }
 
 .button:focus {

--- a/src/components/Insurance/ActiveInsurance.tsx
+++ b/src/components/Insurance/ActiveInsurance.tsx
@@ -36,7 +36,7 @@ const InsuranceDisplay = ({ option }: { option: OptionWithPosition }) => {
           expires {option.dateRich}
         </Typography>
         <button
-          className={`${styles.button} ${styles.green}`}
+          className={styles.green}
           disabled={txPending}
           onClick={handleButtonClick}
         >

--- a/src/components/Insurance/BuyInsuranceBox.tsx
+++ b/src/components/Insurance/BuyInsuranceBox.tsx
@@ -76,7 +76,7 @@ const BuyInsuranceButton = ({ option, size }: BuyButtonProps) => {
 
   return (
     <button
-      className={`${buttonStyles.button} ${buttonStyles.secondary}`}
+      className={buttonStyles.secondary}
       disabled={txPending}
       onClick={handleButtonClick}
     >

--- a/src/components/Insurance/BuyInsuranceModal.tsx
+++ b/src/components/Insurance/BuyInsuranceModal.tsx
@@ -120,7 +120,7 @@ const WithOption = ({ option, size, updateTradeState }: Props) => {
         </Box>
       </Box>
       <button
-        className={`${buttonStyles.button} ${buttonStyles.green}`}
+        className={buttonStyles.green}
         disabled={!account}
         onClick={handleClick}
       >

--- a/src/components/Insurance/ClaimInsurance.tsx
+++ b/src/components/Insurance/ClaimInsurance.tsx
@@ -41,7 +41,7 @@ const ClaimItem = ({
           You are eligible to claim ${option.value.toFixed(4)}
         </Typography>
         <button
-          className={`${styles.button} ${styles.green}`}
+          className={styles.green}
           onClick={handleButtonClick}
           disabled={txPending}
         >

--- a/src/components/MultiDialog/MultiDialog.tsx
+++ b/src/components/MultiDialog/MultiDialog.tsx
@@ -18,7 +18,6 @@ import { ClosePosition } from "../ClosePosition/ClosePosition";
 import { WalletInfo } from "../WalletInfo/WalletInfo";
 import { ReactNode } from "react";
 import { BuyInsuranceModal } from "../Insurance/BuyInsuranceModal";
-import buttonStyles from "../../style/button.module.css";
 import { TransferDialog } from "../Transfer";
 
 const NetworkMismatch = () => (
@@ -35,7 +34,7 @@ const NetworkMismatch = () => (
       </DialogContentText>
     </DialogContent>
     <DialogActions>
-      <button className={buttonStyles.button} onClick={closeDialog} autoFocus>
+      <button onClick={closeDialog} autoFocus>
         Close
       </button>
     </DialogActions>
@@ -61,7 +60,7 @@ const MetamaskMissing = () => (
       </DialogContentText>
     </DialogContent>
     <DialogActions>
-      <button className={buttonStyles.button} onClick={closeDialog} autoFocus>
+      <button onClick={closeDialog} autoFocus>
         Close
       </button>
     </DialogActions>
@@ -91,7 +90,7 @@ const NotEnoughUnlocked = () => (
       </DialogContentText>
     </DialogContent>
     <DialogActions>
-      <button className={buttonStyles.button} onClick={closeDialog} autoFocus>
+      <button onClick={closeDialog} autoFocus>
         Close
       </button>
     </DialogActions>

--- a/src/components/PositionTable/InMoneyItem.tsx
+++ b/src/components/PositionTable/InMoneyItem.tsx
@@ -62,7 +62,7 @@ export const InMoneyItem = ({ option }: Props) => {
       </TableCell>
       <TableCell align="right">
         <button
-          className={`${buttonStyles.button} ${buttonStyles.green}`}
+          className={buttonStyles.green}
           onClick={handleSettle}
           disabled={txPending}
         >

--- a/src/components/PositionTable/LiveItem.tsx
+++ b/src/components/PositionTable/LiveItem.tsx
@@ -4,7 +4,6 @@ import { TableCell, TableRow, Tooltip } from "@mui/material";
 import { openCloseOptionDialog, setCloseOption } from "../../redux/actions";
 import { useTxPending } from "../../hooks/useRecentTxs";
 import { TransactionAction } from "../../redux/reducers/transactions";
-import buttonStyles from "../../style/button.module.css";
 
 type Props = {
   option: OptionWithPosition;
@@ -42,11 +41,7 @@ export const LiveItem = ({ option }: Props) => {
         </Tooltip>
       </TableCell>
       <TableCell align="right">
-        <button
-          className={buttonStyles.button}
-          onClick={handleClick}
-          disabled={txPending}
-        >
+        <button onClick={handleClick} disabled={txPending}>
           {txPending ? "Processing..." : "Close"}
         </button>
       </TableCell>

--- a/src/components/PositionTable/OutOfMoneyItem.tsx
+++ b/src/components/PositionTable/OutOfMoneyItem.tsx
@@ -47,7 +47,7 @@ export const OutOfMoneyItem = ({ option }: Props) => {
       <TableCell>{size.toFixed(decimals)}</TableCell>
       <TableCell align="right">
         <button
-          className={`${buttonStyles.button} ${buttonStyles.green}`}
+          className={buttonStyles.green}
           onClick={handleSettle}
           disabled={txPending}
         >

--- a/src/components/Slippage/SlippageContent.tsx
+++ b/src/components/Slippage/SlippageContent.tsx
@@ -68,15 +68,9 @@ export const SlippageContent = () => {
             variant="contained"
             aria-label="outlined primary button group"
           >
-            <button className={styles.button} onClick={() => handleClick(1)}>
-              1%
-            </button>
-            <button className={styles.button} onClick={() => handleClick(5)}>
-              5%
-            </button>
-            <button className={styles.button} onClick={() => handleClick(10)}>
-              10%
-            </button>
+            <button onClick={() => handleClick(1)}>1%</button>
+            <button onClick={() => handleClick(5)}>5%</button>
+            <button onClick={() => handleClick(10)}>10%</button>
           </ButtonGroup>
         </div>
         <div>

--- a/src/components/StakeCapital/StakeItem.tsx
+++ b/src/components/StakeCapital/StakeItem.tsx
@@ -139,7 +139,7 @@ export const StakeCapitalItem = ({ account, pool }: Props) => {
       </TableCell>
       <TableCell sx={{ display: "flex", alignItems: "center" }} align="right">
         <button
-          className={`${buttonStyles.button} ${buttonStyles.secondary}`}
+          className={buttonStyles.secondary}
           disabled={loading || !account || txPending}
           onClick={handleStakeClick}
         >

--- a/src/components/TradeTable/TradeCard.tsx
+++ b/src/components/TradeTable/TradeCard.tsx
@@ -128,11 +128,7 @@ export const TradeCard = ({ option }: TradeCardProps) => {
   if (loading || !data || !premiaMath64) {
     const graph = () => <LoadingAnimation />;
     const profitTable = () => <ProfitTableSkeleton symbol={option.symbol} />;
-    const buyButton = () => (
-      <button className={`${buttonStyles.button}`} disabled>
-        Loading...
-      </button>
-    );
+    const buyButton = () => <button disabled>Loading...</button>;
 
     return (
       <TradeCardTemplate
@@ -193,7 +189,7 @@ export const TradeCard = ({ option }: TradeCardProps) => {
 
   const BuyButton = () => (
     <button
-      className={`${buttonStyles.button} ${buttonStyles.green}`}
+      className={buttonStyles.green}
       disabled={tradeState.processing || !account || loading}
       onClick={handleBuy}
     >

--- a/src/components/Transfer/TransferButton.tsx
+++ b/src/components/Transfer/TransferButton.tsx
@@ -1,5 +1,4 @@
 import { TransferState, transferLpCapital, userLpBalance } from "./transfer";
-import buttonStyles from "../../style/button.module.css";
 import { useAccount } from "../../hooks/useAccount";
 import { useState } from "react";
 
@@ -21,24 +20,16 @@ export const TransferButton = () => {
   return (
     <div style={{ margin: "1rem" }}>
       {txState === TransferState.Initial && (
-        <button className={buttonStyles.button} onClick={handleClick}>
-          CLICK ME!
-        </button>
+        <button onClick={handleClick}>CLICK ME!</button>
       )}
       {txState === TransferState.Processing && (
-        <button className={buttonStyles.button} disabled={true}>
-          Working...
-        </button>
+        <button disabled={true}>Working...</button>
       )}
       {txState === TransferState.Success && (
-        <button className={buttonStyles.button} disabled={true}>
-          All done!
-        </button>
+        <button disabled={true}>All done!</button>
       )}
       {txState === TransferState.Fail && (
-        <button className={buttonStyles.button} disabled={true}>
-          Failed, please try again
-        </button>
+        <button disabled={true}>Failed, please try again</button>
       )}
     </div>
   );

--- a/src/components/Transfer/TransferDialog.tsx
+++ b/src/components/Transfer/TransferDialog.tsx
@@ -5,7 +5,6 @@ import {
   DialogActions,
 } from "@mui/material";
 import { closeDialog } from "../../redux/actions";
-import buttonStyles from "../../style/button.module.css";
 import { useSelector } from "react-redux";
 import { RootState } from "../../redux/store";
 import { shortInteger } from "../../utils/computations";
@@ -56,11 +55,7 @@ export const TransferDialog = () => {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <button
-              className={buttonStyles.button}
-              onClick={handleClick}
-              autoFocus
-            >
+            <button onClick={handleClick} autoFocus>
               Transfer Capital
             </button>
           </DialogActions>
@@ -74,11 +69,7 @@ export const TransferDialog = () => {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <button
-              className={buttonStyles.button}
-              onClick={closeDialog}
-              autoFocus
-            >
+            <button onClick={closeDialog} autoFocus>
               Close
             </button>
           </DialogActions>
@@ -92,11 +83,7 @@ export const TransferDialog = () => {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <button
-              className={buttonStyles.button}
-              onClick={closeDialog}
-              autoFocus
-            >
+            <button onClick={closeDialog} autoFocus>
               Close
             </button>
           </DialogActions>
@@ -110,11 +97,7 @@ export const TransferDialog = () => {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <button
-              className={buttonStyles.button}
-              onClick={closeDialog}
-              autoFocus
-            >
+            <button onClick={closeDialog} autoFocus>
               Close
             </button>
           </DialogActions>

--- a/src/components/WithdrawCapital/WithdrawItem.tsx
+++ b/src/components/WithdrawCapital/WithdrawItem.tsx
@@ -71,22 +71,18 @@ export const WithdrawItem = ({ account, userPoolInfo }: Props) => {
           disabled={processing || txPending}
         >
           {processing || txPending ? (
-            <button
-              className={`${buttonStyles.button} ${buttonStyles.secondary}`}
-            >
-              Processing...
-            </button>
+            <button className={buttonStyles.secondary}>Processing...</button>
           ) : (
             <>
               <button
                 style={{ borderRight: 0 }}
-                className={`${buttonStyles.button} ${buttonStyles.secondary}`}
+                className={buttonStyles.secondary}
                 onClick={handleWithdraw}
               >
                 Unstake
               </button>
               <button
-                className={`${buttonStyles.button} ${buttonStyles.secondary}`}
+                className={buttonStyles.secondary}
                 onClick={handleWithdrawAll}
               >
                 Max

--- a/src/pages/portfolio.tsx
+++ b/src/pages/portfolio.tsx
@@ -19,13 +19,13 @@ const Portfolio = () => {
   const { target } = useParams();
   const scrollToTarget = (targetRef: RefObject<HTMLDivElement>) => {
     if (targetRef.current) {
-      targetRef.current.scrollIntoView({ behavior: 'smooth' });
+      targetRef.current.scrollIntoView({ behavior: "smooth" });
     }
   };
   useEffect(() => {
     document.title = "Portfolio | Carmine Finance";
     // Check if the URL contains the #history hash
-    switch (target){
+    switch (target) {
       case "history":
         scrollToTarget(history);
         setPortfolioParam(PortfolioParamType.History);
@@ -39,7 +39,7 @@ const Portfolio = () => {
         setPortfolioParam(PortfolioParamType.Position);
         break;
       default:
-        switch (portfolioParam){
+        switch (portfolioParam) {
           case PortfolioParamType.History:
             scrollToTarget(history);
             setPortfolioParam(PortfolioParamType.History);
@@ -63,23 +63,49 @@ const Portfolio = () => {
 
   return (
     <Layout>
-        <button
-          className={`${buttonStyles.button} ${portfolioParam===PortfolioParamType.AirDrop && buttonStyles.secondary} ${buttonStyles.offset}`}
-          onClick={() => {navigate(`/portfolio/airdrop`);}}
-        > Airdrop
-        </button>
-        <button
-          className={`${buttonStyles.button} ${portfolioParam===PortfolioParamType.Position &&buttonStyles.secondary} ${buttonStyles.offset}`}
-          onClick={() => {navigate(`/portfolio/position`);}}
-        > Position
-        </button>
-        <button
-          className={`${buttonStyles.button} ${portfolioParam===PortfolioParamType.History &&buttonStyles.secondary}`}
-          onClick={() => {navigate( `/portfolio/history`);  }}
-        > History
-        </button>
-      {portfolioParam === PortfolioParamType.AirDrop&&(<div ref={airDrop}><Airdrop /></div>)}
-      {portfolioParam === PortfolioParamType.Position&&(<div ref={position}><Positions /></div>)}
+      <button
+        className={`${
+          portfolioParam === PortfolioParamType.AirDrop &&
+          buttonStyles.secondary
+        } ${buttonStyles.offset}`}
+        onClick={() => {
+          navigate(`/portfolio/airdrop`);
+        }}
+      >
+        Airdrop
+      </button>
+      <button
+        className={`${
+          portfolioParam === PortfolioParamType.Position &&
+          buttonStyles.secondary
+        } ${buttonStyles.offset}`}
+        onClick={() => {
+          navigate(`/portfolio/position`);
+        }}
+      >
+        Position
+      </button>
+      <button
+        className={`${
+          portfolioParam === PortfolioParamType.History &&
+          buttonStyles.secondary
+        }`}
+        onClick={() => {
+          navigate(`/portfolio/history`);
+        }}
+      >
+        History
+      </button>
+      {portfolioParam === PortfolioParamType.AirDrop && (
+        <div ref={airDrop}>
+          <Airdrop />
+        </div>
+      )}
+      {portfolioParam === PortfolioParamType.Position && (
+        <div ref={position}>
+          <Positions />
+        </div>
+      )}
       {portfolioParam === PortfolioParamType.History && (
         <div ref={history}>
           <h3 id="history">History</h3>

--- a/src/pages/termsAndConditions.tsx
+++ b/src/pages/termsAndConditions.tsx
@@ -2,7 +2,6 @@ import Typography from "@mui/material/Typography";
 import { Box, Link, useTheme } from "@mui/material";
 import { useEffect } from "react";
 import { setCookieWithExpiry } from "../utils/cookies";
-import buttonStyles from "../style/button.module.css";
 
 const HIDE_TIME_MS = 12 * 60 * 60 * 1000; // 12 hours in ms
 
@@ -58,10 +57,7 @@ const TermsAndConditions = ({ check, rerender }: Props) => {
         . It's important to read and understand these terms before using our
         service.
       </Typography>
-      <button
-        className={buttonStyles.button}
-        onClick={() => storeTermsAndConditions(check, rerender)}
-      >
+      <button onClick={() => storeTermsAndConditions(check, rerender)}>
         Accept Terms and Conditions
       </button>
     </Box>

--- a/src/style/base.css
+++ b/src/style/base.css
@@ -20,3 +20,28 @@ h4 {
   font-size: 24px;
   font-weight: 400;
 }
+
+button {
+  align-items: center;
+  background-color: transparent;
+  border: 2px solid white;
+  border-radius: 2px;
+  box-sizing: border-box;
+  color: white;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 18px;
+  font-weight: 500;
+  height: 50px;
+  justify-content: center;
+  line-height: 24px;
+  min-width: 140px;
+  outline: 0;
+  padding: 0 17px;
+  text-align: center;
+  text-decoration: none;
+  transition: all .3s;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+}

--- a/src/style/button.module.css
+++ b/src/style/button.module.css
@@ -1,28 +1,3 @@
-.button {
-  align-items: center;
-  background-color: transparent;
-  border: 2px solid white;
-  border-radius: 2px;
-  box-sizing: border-box;
-  color: white;
-  cursor: pointer;
-  display: inline-flex;
-  font-size: 18px;
-  font-weight: 500;
-  height: 50px;
-  justify-content: center;
-  line-height: 24px;
-  min-width: 140px;
-  outline: 0;
-  padding: 0 17px;
-  text-align: center;
-  text-decoration: none;
-  transition: all .3s;
-  user-select: none;
-  -webkit-user-select: none;
-  touch-action: manipulation;
-}
-
 .secondary {
   border: 2px solid #FAB000;
   color: #FAB000;
@@ -32,33 +7,9 @@
   border: 2px solid #1AFF00;
   color: #1AFF00;
 }
-.offset{
-  margin-right: 1rem;
-}
 
-.container button {
-  align-items: center;
-  background-color: transparent;
-  border: 2px solid white;
-  border-radius: 2px;
-  box-sizing: border-box;
-  color: white;
-  cursor: pointer;
-  display: inline-flex;
-  font-size: 18px;
-  font-weight: 500;
-  height: 50px;
-  justify-content: center;
-  line-height: 24px;
-  min-width: 140px;
-  outline: 0;
-  padding: 0 17px;
-  text-align: center;
-  text-decoration: none;
-  transition: all .3s;
-  user-select: none;
-  -webkit-user-select: none;
-  touch-action: manipulation;
+.offset {
+  margin-right: 1rem;
 }
 
 .container button:nth-child(odd) {


### PR DESCRIPTION
Currently all buttons need to have `button` class:
```
import buttonStyles from "../style/button.module.css";

<button className={buttonStyles.button}>Click me!</button>
```

Moving button styles to base will automatically style every `button` element without having to add the class.